### PR TITLE
Handle auth refresh without reloading WebView

### DIFF
--- a/app/src/main/java/com/sulhoe/aura/ui/AuraContainer.kt
+++ b/app/src/main/java/com/sulhoe/aura/ui/AuraContainer.kt
@@ -14,12 +14,18 @@ import com.sulhoe.aura.ui.components.AuraTopBar
 import com.sulhoe.aura.ui.web.NoticeDetailWebView
 import com.sulhoe.aura.ui.web.NoticeListWebView
 import com.sulhoe.aura.ui.web.WebBridge
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
 
 @Composable
 fun AuraContainer(
     frontOrigin: String, apiOrigin: String, appScheme: String, frontEntryUrl: String
 ) {
     val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     var currentTab by remember { mutableStateOf("home") }
     var detailUrl by remember { mutableStateOf<String?>(null) }
@@ -55,27 +61,57 @@ fun AuraContainer(
         // 1. 웹에게 "재인증 중" 상태 즉시 전파
         WebBridge.setAuthState("reauthenticating")
 
-        // 2. 백그라운드에서 토큰 갱신 시도
-        WebBridge.listWebView?.postUrl("$apiOrigin/api/auth/refresh", ByteArray(0))
+        val sessionCookie = CookieManager.getInstance().getCookie("$apiOrigin/")
+        if (sessionCookie.isNullOrBlank()) {
+            WebBridge.setAuthState("failed")
+            reauthInFlight = false
+            WebBridge.listWebView?.postDelayed({ WebBridge.setAuthState("idle") }, 500)
+            openOAuthInCustomTab()
+            return
+        }
 
-        // 3. 1초 후 쿠키 상태 확인 (네트워크 지연 고려)
-        WebBridge.listWebView?.postDelayed({
-            try {
-                if (hasBackendSessionCookie()) {
-                    // 3a. 성공: 웹에게 알리고 리로드하여 새 세션 적용
-                    WebBridge.setAuthState("success")
-                    WebBridge.listWebView?.reload()
-                } else {
-                    // 3b. 실패: 웹에게 알리고 OAuth 열기
-                    WebBridge.setAuthState("failed")
-                    openOAuthInCustomTab()
-                }
-            } finally {
-                // 4. 모든 과정이 끝나면 플래그 해제하고, 잠시 후 상태를 'idle'로 복귀
-                reauthInFlight = false
-                WebBridge.listWebView?.postDelayed({ WebBridge.setAuthState("idle") }, 500)
+        scope.launch {
+            val refreshResult = withContext(Dispatchers.IO) {
+                runCatching {
+                    val url = URL("$apiOrigin/api/auth/refresh")
+                    val connection = (url.openConnection() as HttpURLConnection).apply {
+                        requestMethod = "POST"
+                        doOutput = true
+                        setFixedLengthStreamingMode(0)
+                        setRequestProperty("Cookie", sessionCookie)
+                        setRequestProperty("Accept", "*/*")
+                    }
+
+                    connection.outputStream.use { }
+                    val responseCode = connection.responseCode
+                    val setCookies = connection.headerFields["Set-Cookie"].orEmpty()
+                    try {
+                        connection.inputStream?.close()
+                    } catch (_: Exception) {
+                    }
+                    connection.errorStream?.close()
+                    connection.disconnect()
+
+                    responseCode to setCookies
+                }.getOrNull()
             }
-        }, 1000) // 쿠키 정착 및 네트워크 시간 대기를 1초로 조정
+
+            val (responseCode, setCookies) = refreshResult ?: (-1 to emptyList<String>())
+            val cookieManager = CookieManager.getInstance()
+            setCookies.forEach { cookieManager.setCookie(apiOrigin, it) }
+            cookieManager.flush()
+
+            val success = responseCode in 200..299 && hasBackendSessionCookie()
+            if (success) {
+                WebBridge.setAuthState("success")
+            } else {
+                WebBridge.setAuthState("failed")
+                openOAuthInCustomTab()
+            }
+
+            reauthInFlight = false
+            WebBridge.listWebView?.postDelayed({ WebBridge.setAuthState("idle") }, 500)
+        }
     }
 
     fun logoutFlow() {


### PR DESCRIPTION
## Summary
- replace the WebView-based refresh call with an HTTP request performed on a coroutine
- update cookies from the refresh response and emit auth state updates without forcing a reload
- fall back to the OAuth flow immediately when no session cookie is present

## Testing
- `./gradlew lint` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d21a6eae948325a10a0e70de22e202